### PR TITLE
Change packaging to use mono 5

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,10 +43,10 @@ NUGET_URL = https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe
 all: debug
 
 download_nuget:
-	wget -O build/nuget.exe $(NUGET_URL) || curl -o build/nuget.exe -L $(NUGET_URL)
+	build/multitry wget -O build/nuget.exe $(NUGET_URL) || build/multitry curl -o build/nuget.exe -L $(NUGET_URL)
 
 download_dependencies: download_nuget
-	. ./environ && mono build/nuget.exe restore .nuget/packages.config -NonInteractive -PackagesDirectory "$(ROOTDIR)/packages"
+	. ./environ && build/multitry mono build/nuget.exe restore .nuget/packages.config -NonInteractive -PackagesDirectory "$(ROOTDIR)/packages"
 	cp -a packages/Geckofx45.64.Linux.45.0.21.0/build/Geckofx-Core.dll.config packages/Geckofx45.64.Linux.45.0.21.0/lib/net40
 	cp -a packages/Geckofx45.32.Linux.45.0.21.0/build/Geckofx-Core.dll.config packages/Geckofx45.32.Linux.45.0.21.0/lib/net40
 

--- a/build/msbuild.sh
+++ b/build/msbuild.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
+# Run msbuild
+#
 # $1 is the value of the MONO variable set by configure
 # $2 is the value of the MONO_LDFLAGS variable set by configure
-# any following arguments are passed on to xbuild proper
-# build with /usr/local/bin/mono on developer machines if it's the default
+# Any following arguments are passed on.
+
+log() {
+  echo msbuild.sh[$$]: "$@"
+}
+
+# Build with /usr/local/bin/mono on developer machines if it's the default
 if [ "$(which mono)" = "/usr/local/bin/mono" ]; then
-	echo adjusting PATH and LD_LIBRARY_PATH
+	log Adjusting PATH and LD_LIBRARY_PATH
 	export PATH=/usr/local/bin:$PATH
 	export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 elif [ "$1" != "$(which mono)" ]; then
-	echo adjusting PATH and LD_LIBRARY_PATH
+	log Adjusting PATH and LD_LIBRARY_PATH
 	export PATH=$(dirname $1):$PATH
 	# note that MONO_LDFLAGS starts with -L, which we don't want
 	export LD_LIBRARY_PATH=$(echo $2|cut -c3-):$LD_LIBRARY_PATH
 fi
-echo PATH=$PATH
-echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+log PATH=$PATH
+log LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 shift 2
 msbuild "$@"

--- a/build/multitry
+++ b/build/multitry
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run a command a few times until it works, pausing between attempts.
+
+delay=${MULTITRY_DELAY:-1m}
+retries=${MULTITRY_ATTEMPTS:-3}
+while ((retries-- > 0)); do
+	"$@" && exit 0
+	if ((retries <= 0)); then
+		echo >&2 "Giving up"
+		exit 1
+	fi
+	echo >&2 "Retrying $retries more time(s)"
+	sleep ${delay}
+done

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fieldworks-enc-converters (4.0.7.1) focal; urgency=medium
+
+  * Use mono 5.
+
+ -- MarkS <marksvc@gmail.com>  Wed, 12 Feb 2020 10:40:14 -0600
+
 fieldworks-enc-converters (4.0.7) precise; urgency=low
 
   * Add Replaces and Breaks to ease upgrading fieldworks-applications from 8.1.4.

--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: fieldworks-enc-converters
 Priority: optional
 Section: libs
 Maintainer: Stephen McConnel <stephen_mcconnel@sil.org>
-Build-Depends: debhelper (>= 7.0.50~), autotools-dev, python-dev (>=2.6),
+Build-Depends: debhelper (>= 7.0.50~), autotools-dev, python2-dev (>=2.6) | python-dev (>=2.6),
  dh-autoreconf, lsb-release, devscripts,
  libteckit-dev,
  pkg-config,
  mono-runtime,
- mono-sil, libgdiplus-sil,
+ mono5-sil, libgdiplus5-sil, mono5-sil-msbuild,
  icu-dev-fw | fieldworks-applications (<< 9.0.0~),
  wget
 Standards-Version: 3.9.6
@@ -15,7 +15,7 @@ Homepage: https://github.com/silnrsi/encoding-converters-core
 
 Package: fieldworks-enc-converters
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, mono-sil, libgdiplus-sil,
+Depends: ${shlibs:Depends}, ${misc:Depends}, mono5-sil, libgdiplus5-sil,
  libsilcc0,
 Suggests: fieldworks
 Conflicts: enc-converters

--- a/debian/rules
+++ b/debian/rules
@@ -1,29 +1,17 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
-# Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 export DH_OPTIONS=-v
-
 export MONO_PREFIX=/opt/mono5-sil
-export FIELDWORKS=1
 
-# Help nuget by providing a writable settings directory.
-export XDG_CONFIG_HOME=$(shell mktemp -d --tmpdir xdg_config_home.XXXXX)
+# NuGet has trouble when Ubuntu 16.04 pbuilder sets the home directory to /nonexistent. Set a HOME for NuGet to use.
+export HOME=`mktemp -d --tmpdir nuget_home.XXXXX`
 
 %:
-	dh --with autoreconf $@
+	. ./environ && dh $@ --with autoreconf
 
 override_dh_auto_clean:
 
-# note that the Makefile determines the installation directory based on the
-# existence/value of the variable FIELDWORKS, so we don't need a --prefix
-# argument for autogen.sh
 override_dh_autoreconf:
 	./autogen.sh
 

--- a/environ
+++ b/environ
@@ -1,8 +1,9 @@
 # Environment settings to build fieldworks encoding converters.
 #
 # Source, not run, this file
-# TODO It would probably be good to combine this with msbuild.sh. And debian/rules.
+# TODO It would probably be good to combine this with msbuild.sh.
 
 export PATH="/opt/mono5-sil/bin:${PATH}"
 export FIELDWORKS=1
 export LD_LIBRARY_PATH="/usr/lib/fieldworks/lib:${LD_LIBRARY_PATH}"
+export PYTHON_VERSION="2.7"

--- a/src/AIGuesserEC/AIGuesserEC-mono.csproj
+++ b/src/AIGuesserEC/AIGuesserEC-mono.csproj
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\output\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <RegisterForComInterop>false</RegisterForComInterop>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
-    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -55,6 +42,19 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RegisterForComInterop>false</RegisterForComInterop>
     <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
+    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\..\output\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
@@ -245,7 +245,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/EncCnvtrs/EncCnvtrs-mono.csproj
+++ b/src/EncCnvtrs/EncCnvtrs-mono.csproj
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\output\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <BaseAddress>285212672</BaseAddress>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <RegisterForComInterop>false</RegisterForComInterop>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
-    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.21022</ProductVersion>
@@ -73,6 +58,21 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
+    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\output\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <BaseAddress>285212672</BaseAddress>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
     <RegisterForComInterop>false</RegisterForComInterop>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
* Change depends and build-depends to mono5-sil and libgdiplus5-sil to
more easily run on Ubuntu 20.04.
* Add msbuild dependency.
* Put $@ first in debian/rules dh command to be ready for future
compatibility levels of dh.
* In debian/rules, use environ to set the environment over all the
packaging steps.
- Removing FIELDWORKS=1 since is in environ.
* Give msbuild.sh output some context.
* Newer nuget seems to need more help than just XDG_CONFIG_HOME or
XDG_DATA_HOME. Setting HOME instead since otherwise HOME is
/nonexistent, causing a problem for nuget downloading.
* Reorder the Release section of a couple csproj files so `make
release` works.
* Broaded dependency to python2-dev, still in Ubuntu 20.04 universe.
- Set PYTHON_VERSION="2.7" in `environ` so configure finds the
`python2.7` executable instead of looking for `python` and not finding
it.
* Make downloading with wget and nuget be retried a few times, so that
network problems on the build server are less likely to fail a job.