### PR TITLE
Bump version to 4.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-fieldworks-enc-converters (4.0.7.1) focal; urgency=medium
+fieldworks-enc-converters (4.0.8) focal; urgency=medium
 
   * Use mono 5.
 


### PR DESCRIPTION
4.0.7.1 would have worked except it conflicted with automated build
versioning.