### PR TITLE
Allow skipping dependency downloads

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,12 +43,16 @@ NUGET_URL = https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe
 all: debug
 
 download_nuget:
+ifneq ($(EC_DOWNLOAD_DEPS), false)
 	build/multitry wget -O build/nuget.exe $(NUGET_URL) || build/multitry curl -o build/nuget.exe -L $(NUGET_URL)
+endif
 
 download_dependencies: download_nuget
+ifneq ($(EC_DOWNLOAD_DEPS), false)
 	. ./environ && build/multitry mono build/nuget.exe restore .nuget/packages.config -NonInteractive -PackagesDirectory "$(ROOTDIR)/packages"
 	cp -a packages/Geckofx45.64.Linux.45.0.21.0/build/Geckofx-Core.dll.config packages/Geckofx45.64.Linux.45.0.21.0/lib/net40
 	cp -a packages/Geckofx45.32.Linux.45.0.21.0/build/Geckofx-Core.dll.config packages/Geckofx45.32.Linux.45.0.21.0/lib/net40
+endif
 
 debug: download_dependencies
 	@cd build && ./msbuild.sh $(MONO) $(MONO_LDFLAGS) /property:FIELDWORKS=$(FIELDWORKS)


### PR DESCRIPTION
- By building with EC_DOWNLOAD_DEPS=false
- This is helpful in environments that discourage networking while building.