### PR TITLE
fixed an issue where using non-Ansi unicode characters in the find-what text of a Icu Regex search doesn't work. 

### DIFF
--- a/src/IcuEC/IcuRegexCpp/IcuRegexEC.cpp
+++ b/src/IcuEC/IcuRegexCpp/IcuRegexEC.cpp
@@ -30,7 +30,7 @@
 // have the same name in other converters, for example Load().
 namespace IcuRegexEC
 {
-    char *          m_strConverterSpec = NULL;
+	icu::UnicodeString	 m_strConverterSpec;
 	icu::UnicodeString   m_strFind;
 	icu::UnicodeString   m_strReplace;
 	icu::RegexMatcher*   m_pMatcher;
@@ -116,11 +116,6 @@ namespace IcuRegexEC
             delete m_pMatcher;
             m_pMatcher = 0;
         }
-        if (m_strConverterSpec != 0)
-        {
-            free(m_strConverterSpec);
-            m_strConverterSpec = NULL;
-        }
     }
 
     // the format of the converter spec for ICU regular expressions is:
@@ -137,7 +132,7 @@ namespace IcuRegexEC
     //
     bool ParseConverterSpec
     (
-        char *    strConverterSpec,
+		icu::UnicodeString	strConverterSpec,
         char *    &strFind,      // string passed by reference
         char *    &strReplace,   // string passed by reference
         bool      &bIgnoreCase
@@ -148,17 +143,18 @@ namespace IcuRegexEC
         // BUT BEWARE, is there any reason that they couldn't have spaces
         // in there? So instead of using 
         // RegexMatcher::split, do it more carefully
-        char * found = strstr(strConverterSpec, clpszFindReplaceDelimiter);
+		char* lpConverterSpec = UniStr_to_CharStar(strConverterSpec);
+        char * found = strstr(lpConverterSpec, clpszFindReplaceDelimiter);
         if (found == NULL)
             return false;
 
         // set strFind to everything up to but not including the delimiter,
         // and strReplace to everything after the delimiter.
-        strFind = strndup(strConverterSpec,
-                     strlen(strConverterSpec) - strlen(found));
+        strFind = strndup(lpConverterSpec,
+                     strlen(lpConverterSpec) - strlen(found));
         strReplace = _strdup(found + strlen(clpszFindReplaceDelimiter));
 
-        found = strstr(strConverterSpec, clpszCaseInsensitiveFlag);
+        found = strstr(lpConverterSpec, clpszCaseInsensitiveFlag);
         if (found != NULL)
         {
             bIgnoreCase = true;
@@ -251,7 +247,7 @@ namespace IcuRegexEC
         if( IsMatcherLoaded() )
             FinalRelease();
 
-        m_strConverterSpec = _strdup(strConverterSpec);
+		m_strConverterSpec.setTo(strConverterSpec);
 
         // do the load at this point; not that we need it, but for checking that everything's okay.
         return Load();
@@ -355,9 +351,9 @@ namespace IcuRegexEC
 // Global wrappers to call the functions inside the namespace.
 //******************************************************************************
 
-int IcuRegexEC_Initialize(char * strConverterID)
+int IcuRegexEC_Initialize(char * lpConverterID)
 {
-    return IcuRegexEC::Initialize(strConverterID);
+    return IcuRegexEC::Initialize(lpConverterID);
 }
 int IcuRegexEC_PreConvert (int eInEncodingForm, int& eInFormEngine,
     int eOutEncodingForm, int& eOutFormEngine,

--- a/src/TestEncCnvtrs/TestIcuRegex.cs
+++ b/src/TestEncCnvtrs/TestIcuRegex.cs
@@ -50,6 +50,27 @@ namespace TestEncCnvtrs
 			Assert.AreEqual("पोथी रे ते मियाः  हेनाः", output,
 				"ICU regex converter should work properly for non-latin ranges of unicode also (for which UTF8String won't work on Windows)!");
 		}
+
+		[Test]
+		[TestCase("\\u0930->r", "पोथी रथ", "पोथी rथ")]
+		[TestCase("र->r", "पोथी रथ", "पोथी rथ")]
+		// these don't work bkz the C++ side of it (or maybe a bug in ICU, I can't tell)
+		//  doesn't convert, for example, \\u200d to UTF8 properly
+		// [TestCase("[\\u200c\\u200d]->", "व्‍यक्‌ति", "व्यक्ति")]
+		// [TestCase("[\\u2020\\u2021\\u200c\\u200d\\u230a\\u230b]->", "⌊व्‍यक्‌ति⌋ † ‡", "व्यक्ति  ")]
+		public void TestRegexForUnicodeEscapeCharacters(string converterSpec, string strInput, string strOutput)
+		{
+			var rec = new IcuRegexEncConverter();
+			string lhsEncoding = "UNICODE";
+			string rhsEncoding = "UNICODE";
+			ConvType convType = ConvType.Unicode_to_from_Unicode;
+			int procFlags = (int)ProcessTypeFlags.ICURegularExpression;
+			rec.Initialize("TransliterateDevanagariR", converterSpec,
+				ref lhsEncoding, ref rhsEncoding, ref convType, ref procFlags, 0, 0, false);
+			string output = rec.Convert(strInput);
+			Assert.AreEqual(strOutput, output,
+				$"ICU regex converter should work properly for Unicode Escape sequences (e.g. {converterSpec}) also!");
+		}
 	}
 }
 


### PR DESCRIPTION
There's still a bug if you try to use a zero-width (non-) joiner character in the FindWhat text, which I am giving up trying to solve, but this change at least fixes the issue if your regex search is for non-Ansi characters that were previously clobbered (e.g. \u0930 or even straight devanagari, which were being clobbered by being treated as an Ansi string)